### PR TITLE
Add API Gateway migration notice and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,33 @@ Or, in a [`brew bundle`](https://github.com/Homebrew/homebrew-bundle) `Brewfile`
 
 ```ruby
 tap "fw-ai/firectl"
-brew "<formula>"
+brew "firectl"
 ```
+
+## API Gateway Migration Notice
+
+**Direct Routing is deprecated.** Please migrate to the Fireworks API Gateway for improved reliability and multi-region support.
+
+### Migration Steps
+
+1. **Update your API URL:**
+   - Old: `https://<deployment>.direct.fireworks.ai/v1`
+   - New: `https://api.fireworks.ai/inference/v1`
+
+2. **Update your API key:**
+   - Replace `DIRECT_ROUTE_API_KEY` with your standard `FIREWORKS_API_KEY`
+
+3. **Creating deployments with firectl:**
+   - Multi-region is now enabled by default
+   - If you need single-region deployments, add `--disable-multi-region-sharding` to your `firectl create deployment` command
+
+For detailed migration instructions, see the [Direct Routing Migration Guide](https://docs.fireworks.ai/deployments/direct-routing).
 
 ## Documentation
 
 `brew help`, `man brew` or check [Homebrew's documentation](https://docs.brew.sh).
+
+For firectl documentation, see the [firectl reference](https://readme.fireworks.ai/reference/firectl).
 
 ## Trigger
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR updates the README to help users migrate from Direct Routing to the Fireworks API Gateway, as announced in the deprecation notice.

## Changes

- **Added API Gateway Migration Notice section** with:
  - Clear deprecation warning for Direct Routing
  - Step-by-step migration instructions:
    1. URL change: `direct.fireworks.ai/v1` → `https://api.fireworks.ai/inference/v1`
    2. API key swap: `DIRECT_ROUTE_API_KEY` → `FIREWORKS_API_KEY`
    3. New `--disable-multi-region-sharding` flag for `firectl create deployment` (multi-region is now enabled by default)
  - Link to official [Direct Routing Migration Guide](https://docs.fireworks.ai/deployments/direct-routing)

- **Fixed Brewfile example**: Changed `brew "<formula>"` to `brew "firectl"`

- **Added link to firectl reference documentation**

## Context

Direct Routing is being deprecated in favor of the Fireworks API Gateway, which provides:
- Multi-region reliability (opt-in MR deployments + automatic failover)
- Region flexibility (move deployments without changing client code)
- Sub-10ms overhead for most users
- Automatic retries for many transient errors
- One URL for everything (no more per-deployment URLs)

This documentation update helps users of the Homebrew tap understand the migration requirements when using `firectl` to manage their deployments.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e36a40c2-013b-4bbb-9ac0-ba7a8da90869"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e36a40c2-013b-4bbb-9ac0-ba7a8da90869"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

